### PR TITLE
Week2 project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,37 @@ ifneq (,$(wildcard ./.env))
     export
 endif
 
+
+.PHONY: week1
+week1:
+	docker-compose -f docker/docker-compose-w2.yml up
+
+
+.PHONY: stop-week1
+stop-week1:
+	docker-compose -f docker/docker-compose-w1.yml down
+
+
+.PHONY: week1-query
+week1-query:
+	python week1/query.py --query_file ${QUERY_FILE} --max_queries ${MAX_QUERIES}
+
 .PHONY: start
 start:
-	docker-compose -f docker/docker-compose-w1.yml up
+	docker-compose -f docker/docker-compose-w2.yml up --detach
 
 .PHONY: stop
 stop:
-	docker-compose -f docker/docker-compose-w1.yml down
+	docker-compose -f docker/docker-compose-w2.yml stop
+
+.PHONY: build-week2-opensearch
+build-week2-opensearch:
+	docker build -f docker/Opensearch.Dockerfile -t week2-opensearch:latest .
+
+.PHONY: start-monitoring
+start-monitoring:
+	docker-compose -f docker-grafana/monitoring.yml up
+
 
  .PHONY: mapping
 mapping:
@@ -21,7 +45,7 @@ mapping:
 
 .PHONY: index
 index: delete mapping
-	python3 week1/index.py -s ${BBUY_DATA} --refresh_interval ${REFRESH_INTERVAL} --batch_size ${BATCH_SIZE} --workers ${WORKERS}
+	python3 week2/index.py -s ${BBUY_DATA} --refresh_interval ${REFRESH_INTERVAL} --batch_size ${BATCH_SIZE} --workers ${WORKERS}
 
 .PHONY: delete
 delete:
@@ -38,4 +62,4 @@ track:
 
 .PHONY: query
 query:
-	python week1/query.py --query_file ${QUERY_FILE} --max_queries ${MAX_QUERIES}
+	python week2/query.py --query_file ${QUERY_FILE} --max_queries ${MAX_QUERIES} --workers ${QUERY_WORKERS}

--- a/docker/Opensearch.Dockerfile
+++ b/docker/Opensearch.Dockerfile
@@ -1,0 +1,3 @@
+FROM opensearchproject/opensearch:2.6.0
+
+RUN bin/opensearch-plugin install "https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/releases/download/2.6.0.0/prometheus-exporter-2.6.0.0.zip"

--- a/docker/docker-compose-w2.yml
+++ b/docker/docker-compose-w2.yml
@@ -1,12 +1,12 @@
 version: '3'
 services:
   opensearch-node1:
-    image: opensearchproject/opensearch:2.6.0
+    image: week2-opensearch:latest
     container_name: opensearch-node1
     environment:
       - discovery.type=single-node
       - http.max_content_length=1000mb
-      - "OPENSEARCH_JAVA_OPTS=-Xms1G -Xmx1G"
+      - "OPENSEARCH_JAVA_OPTS=-Xms4G -Xmx4G"
       # Avoid creating security-auditlog index, since that results in unallocated shards on a single node setup.
       # This will send security audit events to stdout instead https://opensearch.org/docs/latest/security/audit-logs/storage-types/
       - plugins.security.audit.type=debug
@@ -24,8 +24,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1'
-          memory: 2GB
+          cpus: '5'
+          memory: 8GB
   opensearch-dashboards:
     image: opensearchproject/opensearch-dashboards:2.6.0
     container_name: opensearch-dashboards

--- a/week1/bbuy_products.json
+++ b/week1/bbuy_products.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    "index": {
+      "number_of_replicas": 0
+    },
     "analysis": {
       "analyzer": {
         "smarter_hyphens": {

--- a/week2/Assesment.md
+++ b/week2/Assesment.md
@@ -1,0 +1,51 @@
+# Week 2 Project
+
+## Level 1
+
+### How long did it take to index the 1.2M product data set? What docs/sec indexing rate did you see?
+With the default configuration (1 CPU, 2GB RAM, 1GB JVM heap, index.py -w 16 -b 500), it took 4.5 minutes. The indexing rate was 5.64 K/sec max and 3.72 K/ sec average.
+
+### Notice that the Index size rose (roughly doubled) while the content was being indexed, peaked, then ~ 5 minutes after indexing stopped, the index size dropped down substantially. Why did it drop back down? (What did OpenSearch do here?)
+When re-indexing without deleting the existing content, OpenSearch did not go through the hustle of replacing the documents in-place. It instead created a separate Lucene segment and do the cleanup for the stale docs afterwards.
+
+### Looking at the metrics dashboard, what queries/sec rate are you getting?
+With the default configuration (1 CPU, 2GB RAM, 1GB JVM heap, query -w 4 -m 25000), rate was around 105 queries/sec
+
+### What resource(s) appear to be the constraining factor?
+CPU was bound to 100%, memory usage was also around 2GB and queue depth during indexing (refresh: 4) and querying (search: 2)
+
+## Level 2
+
+### As you increased CPU and memory in your L2 tests, what seemed to be the constraining factor limiting indexing rate?
+When only CPU setting is increased (5 CPU, 2GB RAM, 1GB JVM heap, index.py -w 16 -b 500), it took 1.8 minutes. The indexing rate was 12 K/sec max and 6.2 K/ sec average. CPU usage averaged %70 and max was 87%.
+Memory usage was the constraining factor at 2GB. 
+
+### As you increased memory in your L2 tests, what seemed to be the constraining factor limiting indexing rate? What was the constraining factor for querying rate?
+When memory is increased (1 CPU, 8GB RAM, 4GB JVM heap, index.py -w 16 -b 500), indexing took 3.6 minutes. The indexing rate was 7 K/sec max and 4.3 K/ sec average. CPU was the constraining factor averaged %98.
+Memory usage was between 4.5GB - 6GB.
+
+When querying (query -w 4 -m 25000), rate was around 128 queries/sec. CPU was the constraining factor averaged %89. Queue depth (search) was at 2.
+Memory usage was between 4.5GB - 6GB.
+
+### Combined
+When CPU & memory is increased (5 CPU, 8GB RAM, 4GB JVM heap, index.py -w 16 -b 500), indexing took 1.7 minutes. The indexing rate was 8.5 K/sec max and 13 K/ sec average. CPU usage averaged %50 and max was 94%.
+Memory usage was between 4.7B - 7GB.
+
+When querying (query -w 4 -m 25000), rate was around 350 queries/sec. CPU usage averaged %60 and max was %75. Queue dept was at 0.
+Memory usage was between 5GB - 7GB.
+
+
+## Level 3
+
+### What is the impact on your query throughput (QPS) and indexing throughput (docs/sec)?
+When CPU & memory is increased (5 CPU, 8GB RAM, 4GB JVM heap, index.py -w 16 -b 500), indexing & querying simultaneously:
+
+The indexing rate was 5.6 K/sec max and 8.4 K/ sec average. The query rate was around 50 queries/sec. CPU usage averaged %80 and max was 100%. Memory usage was 7GB-8GB.
+
+## Level 4
+
+### Can you break the system?
+With a bad setup (1 CPU, 512M RAM, 256M JVM heap and UseSerialGC, index.py -w 16 -b 5000, refresh interval 1s), indexing failed around 600K docs. The indexing rate was 2.8 K/sec max and 2.3 K/ sec average. CPU averaged at %96. Memory usage was 511MB.
+JVM Heap was averaged at %84.
+
+Many status:429 errors were observed during indexing. Container exited with "java.lang.OutOfMemoryError: Java heap space".


### PR DESCRIPTION
# Week 2 Project

## Level 1

### How long did it take to index the 1.2M product data set? What docs/sec indexing rate did you see?
With the default configuration (1 CPU, 2GB RAM, 1GB JVM heap, index.py -w 16 -b 500), it took 4.5 minutes. The indexing rate was 5.64 K/sec max and 3.72 K/ sec average.

### Notice that the Index size rose (roughly doubled) while the content was being indexed, peaked, then ~ 5 minutes after indexing stopped, the index size dropped down substantially. Why did it drop back down? (What did OpenSearch do here?)
When re-indexing without deleting the existing content, OpenSearch did not go through the hustle of replacing the documents in-place. It instead created a separate Lucene segment and do the cleanup for the stale docs afterwards.

### Looking at the metrics dashboard, what queries/sec rate are you getting?
With the default configuration (1 CPU, 2GB RAM, 1GB JVM heap, query -w 4 -m 25000), rate was around 105 queries/sec

### What resource(s) appear to be the constraining factor?
CPU was bound to 100%, memory usage was also around 2GB and queue depth during indexing (refresh: 4) and querying (search: 2)

## Level 2

### As you increased CPU and memory in your L2 tests, what seemed to be the constraining factor limiting indexing rate?
When only CPU setting is increased (5 CPU, 2GB RAM, 1GB JVM heap, index.py -w 16 -b 500), it took 1.8 minutes. The indexing rate was 12 K/sec max and 6.2 K/ sec average. CPU usage averaged %70 and max was 87%.
Memory usage was the constraining factor at 2GB. 

### As you increased memory in your L2 tests, what seemed to be the constraining factor limiting indexing rate? What was the constraining factor for querying rate?
When memory is increased (1 CPU, 8GB RAM, 4GB JVM heap, index.py -w 16 -b 500), indexing took 3.6 minutes. The indexing rate was 7 K/sec max and 4.3 K/ sec average. CPU was the constraining factor averaged %98.
Memory usage was between 4.5GB - 6GB.

When querying (query -w 4 -m 25000), rate was around 128 queries/sec. CPU was the constraining factor averaged %89. Queue depth (search) was at 2.
Memory usage was between 4.5GB - 6GB.

### Combined
When CPU & memory is increased (5 CPU, 8GB RAM, 4GB JVM heap, index.py -w 16 -b 500), indexing took 1.7 minutes. The indexing rate was 8.5 K/sec max and 13 K/ sec average. CPU usage averaged %50 and max was 94%.
Memory usage was between 4.7B - 7GB.

When querying (query -w 4 -m 25000), rate was around 350 queries/sec. CPU usage averaged %60 and max was %75. Queue dept was at 0.
Memory usage was between 5GB - 7GB.


## Level 3

### What is the impact on your query throughput (QPS) and indexing throughput (docs/sec)?
When CPU & memory is increased (5 CPU, 8GB RAM, 4GB JVM heap, index.py -w 16 -b 500), indexing & querying simultaneously:

The indexing rate was 5.6 K/sec max and 8.4 K/ sec average. The query rate was around 50 queries/sec. CPU usage averaged %80 and max was 100%. Memory usage was 7GB-8GB.

## Level 4

### Can you break the system?
With a bad setup (1 CPU, 512M RAM, 256M JVM heap and UseSerialGC, index.py -w 16 -b 5000, refresh interval 1s), indexing failed around 600K docs. The indexing rate was 2.8 K/sec max and 2.3 K/ sec average. CPU averaged at %96. Memory usage was 511MB.
JVM Heap was averaged at %84.

Many status:429 errors were observed during indexing. Container exited with "java.lang.OutOfMemoryError: Java heap space".